### PR TITLE
Upgrade dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
-  meta: ^1.1.8
-  quiver: ^2.1.2
+  meta: ^1.3.0
+  quiver: ^3.0.0
 
 dev_dependencies:
-  test: ^1.5.3
-  pedantic: ^1.9.0
+  test: ^1.16.8
+  pedantic: ^1.11.0


### PR DESCRIPTION
First only upgrade the dependencies.

Even though quiver is now null-safe and has had some breaking changes, none of those breaking changes should affect extended_math.